### PR TITLE
update to compile with zig 0.12 and 0.13

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,19 +1,27 @@
-const Builder = @import("std").build.Builder;
+const Build = @import("std").Build;
 const std = @import("std");
 
-pub fn build(b: *Builder) void {
+pub fn build(b: *Build) void {
     const target = b.standardTargetOptions(.{});
-    const mode = std.builtin.Mode.ReleaseFast;
+    const optimize = b.standardOptimizeOption(.{}); // was: std.builtin.Mode.ReleaseFast;
 
-    const exe = b.addExecutable("sfotool", "src/main.zig");
-    exe.setTarget(target);
-    exe.setBuildMode(mode);
-    exe.setOutputDir("../bin/");
-    exe.install();
+    const exe = b.addExecutable(.{
+        .name = "sfotool",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(exe);
+    // b.getInstallStep().dependOn(&b.addInstallArtifact(
+    //     exe,
+    //     .{
+    //         .dest_dir = .{ .override = .{
+    //             .custom = "../bin/",
+    //         } },
+    //     },
+    // ).step);
 
-    const run_cmd = exe.run();
-    run_cmd.step.dependOn(b.getInstallStep());
-
-    const run_step = b.step("run", "Run the app");
-    run_step.dependOn(&run_cmd.step);
+    const run = b.step("run", "Run the application");
+    const run_cmd = b.addRunArtifact(exe);
+    run.dependOn(&run_cmd.step);
 }

--- a/src/common.zig
+++ b/src/common.zig
@@ -1,45 +1,45 @@
 pub const PSF_MAGIC_NUM = 0x46535000;
 pub const PSF_VERSION = 0x00000101;
 
-pub const SFOHeader = packed struct{
+pub const SFOHeader = packed struct {
     magic: u32,
     version: u32,
     keyofs: u32,
     valofs: u32,
-    count: u32
+    count: u32,
 };
 
-pub const SFOEntry = packed struct{
+pub const SFOEntry = packed struct {
     nameofs: u16,
     alignment: u8,
     typec: u8,
     valsize: u32,
     totalsize: u32,
-    dataofs: u32
+    dataofs: u32,
 };
 
 pub const PSP_TYPE_BIN = 0;
 pub const PSP_TYPE_STR = 2;
 pub const PSP_TYPE_VAL = 4;
 
-pub const EntryContainer = struct{
+pub const EntryContainer = struct {
     name: []const u8,
     typec: i32,
     value: u32,
-    data: ?[]const u8
+    data: ?[]const u8,
 };
 
-pub const g_defaults : [8]EntryContainer = [8]EntryContainer{
-    EntryContainer{ .name = "MEMSIZE",           .typec = PSP_TYPE_VAL, .value  = 1,    .data = null},
-    EntryContainer{ .name = "BOOTABLE",         .typec = PSP_TYPE_VAL, .value  = 1,         .data = null },
-    EntryContainer{ .name = "CATEGORY",         .typec = PSP_TYPE_STR, .value  = 0,         .data = "MG"},
-    EntryContainer{ .name = "DISC_ID",          .typec = PSP_TYPE_STR, .value  = 0,         .data = "UCJS10041"},
-    EntryContainer{ .name = "DISC_VERSION",     .typec = PSP_TYPE_STR, .value  = 0,         .data = "1.00"},
-    EntryContainer{ .name = "PARENTAL_LEVEL",   .typec = PSP_TYPE_VAL, .value  = 1,         .data = null},
-    EntryContainer{ .name = "PSP_SYSTEM_VER",   .typec = PSP_TYPE_STR, .value  = 0,         .data = "1.00"},
-    EntryContainer{ .name = "REGION",           .typec = PSP_TYPE_VAL, .value  = 0x8000,    .data = null},
+pub const g_defaults: [8]EntryContainer = [8]EntryContainer{
+    EntryContainer{ .name = "MEMSIZE", .typec = PSP_TYPE_VAL, .value = 1, .data = null },
+    EntryContainer{ .name = "BOOTABLE", .typec = PSP_TYPE_VAL, .value = 1, .data = null },
+    EntryContainer{ .name = "CATEGORY", .typec = PSP_TYPE_STR, .value = 0, .data = "MG" },
+    EntryContainer{ .name = "DISC_ID", .typec = PSP_TYPE_STR, .value = 0, .data = "UCJS10041" },
+    EntryContainer{ .name = "DISC_VERSION", .typec = PSP_TYPE_STR, .value = 0, .data = "1.00" },
+    EntryContainer{ .name = "PARENTAL_LEVEL", .typec = PSP_TYPE_VAL, .value = 1, .data = null },
+    EntryContainer{ .name = "PSP_SYSTEM_VER", .typec = PSP_TYPE_STR, .value = 0, .data = "1.00" },
+    EntryContainer{ .name = "REGION", .typec = PSP_TYPE_VAL, .value = 0x8000, .data = null },
 };
 
 pub const MAX_OPTIONS = 256;
 
-pub var gVals : [MAX_OPTIONS]EntryContainer = undefined;
+pub var gVals: [MAX_OPTIONS]EntryContainer = undefined;

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,34 +6,33 @@ const parse = @import("parse.zig");
 const read = @import("read.zig");
 
 pub fn main() !void {
-    //Get args
-    var arg_it = process.args();
-    // Skip executable
-    _ = arg_it.skip();
-
     //Allocator setup
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
-    const allocator = &arena.allocator;
+    const allocator = arena.allocator();
 
-    var optionSelected = try (arg_it.next(allocator) orelse{
-        std.debug.warn("Usage: sfotool [read | write | parse] file <...>\n", .{});
-        return;
-    });
+    //Get args
+    var arg_it = try process.argsWithAllocator(allocator);
+    // Skip executable
+    _ = arg_it.skip();
 
-    if(std.mem.eql(u8, optionSelected, "-h")){
-        std.debug.warn("Usage: sfotool [read | write | parse] file <...>\n", .{});
+    const optionSelected = arg_it.next() orelse {
+        std.log.warn("Usage: sfotool [read | write | parse] file <...>\n", .{});
         return;
-    }else if(std.mem.eql(u8, optionSelected, "-v")){    
-        std.debug.warn("zSFOTool Utility made by zPSP-Dev!\n\n", .{});
-        std.debug.warn("Version 1.0\n", .{});
+    };
+
+    if (std.mem.eql(u8, optionSelected, "-h")) {
+        std.log.warn("Usage: sfotool [read | write | parse] file <...>\n", .{});
         return;
-    }else if(std.mem.eql(u8, optionSelected, "read")){
+    } else if (std.mem.eql(u8, optionSelected, "-v")) {
+        std.log.warn("zSFOTool Utility made by zPSP-Dev!\n\n", .{});
+        std.log.warn("Version 1.0\n", .{});
+        return;
+    } else if (std.mem.eql(u8, optionSelected, "read")) {
         try read.readSFO();
-    }else if(std.mem.eql(u8, optionSelected, "write")){
+    } else if (std.mem.eql(u8, optionSelected, "write")) {
         try write.writeSFO();
-    }else if(std.mem.eql(u8, optionSelected, "parse")){
+    } else if (std.mem.eql(u8, optionSelected, "parse")) {
         try parse.parseSFO();
     }
-
 }

--- a/src/read.zig
+++ b/src/read.zig
@@ -1,111 +1,114 @@
 const std = @import("std");
 const process = std.process;
-usingnamespace @import("common.zig");
 const io = std.io;
 const mem = std.mem;
 const fs = std.fs;
 
-//This reads and validates the header
-fn validateHeader(file : fs.File) !SFOHeader {
-    var sfoh : SFOHeader = undefined;
+const common = @import("common.zig");
+const SFOHeader = common.SFOHeader;
+const SFOEntry = common.SFOEntry;
+const PSF_MAGIC_NUM = common.PSF_MAGIC_NUM;
+const PSP_TYPE_VAL = common.PSP_TYPE_VAL;
 
-    sfoh.magic = try file.reader().readIntNative(u32);
-    sfoh.version = try file.reader().readIntNative(u32);
-    sfoh.keyofs = try file.reader().readIntNative(u32);
-    sfoh.valofs = try file.reader().readIntNative(u32);
-    sfoh.count = try file.reader().readIntNative(u32);
-    if(sfoh.magic != PSF_MAGIC_NUM){
+//This reads and validates the header
+fn validateHeader(file: fs.File) !SFOHeader {
+    var sfoh: SFOHeader = undefined;
+
+    sfoh.magic = try file.reader().readInt(u32, .little);
+    sfoh.version = try file.reader().readInt(u32, .little);
+    sfoh.keyofs = try file.reader().readInt(u32, .little);
+    sfoh.valofs = try file.reader().readInt(u32, .little);
+    sfoh.count = try file.reader().readInt(u32, .little);
+    if (sfoh.magic != PSF_MAGIC_NUM) {
         return error.BadMagic;
     }
-    std.debug.warn("Magic Validated! Version 0x{x}\n", .{sfoh.version});
-    std.debug.warn("Found {} key-value pairs!\n\n", .{sfoh.count});
-    
-    std.debug.warn("Keys at 0x{x}\n", .{sfoh.keyofs});
-    std.debug.warn("Data at 0x{x}\n", .{sfoh.valofs});
+    std.log.warn("Magic Validated! Version 0x{x}\n", .{sfoh.version});
+    std.log.warn("Found {} key-value pairs!\n\n", .{sfoh.count});
+
+    std.log.warn("Keys at 0x{x}\n", .{sfoh.keyofs});
+    std.log.warn("Data at 0x{x}\n", .{sfoh.valofs});
 
     return sfoh;
 }
 
 pub fn readSFO() !void {
+    //Allocator setup
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
     //Get args
-    var arg_it = process.args();
+    var arg_it = try process.argsWithAllocator(allocator);
 
     // Skip executable
     _ = arg_it.skip();
     // Skip command
     _ = arg_it.skip();
 
-    //Allocator setup
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-
-    const allocator = &arena.allocator;
-
     //Get our file - if it doesn't exist - error out
-    var inputName = try (arg_it.next(allocator) orelse{
-        std.debug.warn("Usage: sfotool read <input.SFO>\n", .{});
+    const inputName = arg_it.next() orelse {
+        std.log.warn("Usage: sfotool read <input.SFO>\n", .{});
         return;
-    });
+    };
 
-    if(std.mem.eql(u8, inputName, "-h")){
-        std.debug.warn("Usage: sfotool read <input.SFO>\n", .{});
+    if (std.mem.eql(u8, inputName, "-h")) {
+        std.log.warn("Usage: sfotool read <input.SFO>\n", .{});
         return;
     }
 
     //File in
-    var inFile = try fs.cwd().openFile(inputName, fs.File.OpenFlags{.read = true});
+    var inFile = try fs.cwd().openFile(inputName, fs.File.OpenFlags{ .mode = .read_only });
     defer inFile.close();
 
     //Read the header
-    var header : SFOHeader = try validateHeader(inFile);
-    var entries : [256]SFOEntry = undefined;
+    const header: SFOHeader = try validateHeader(inFile);
+    var entries: [256]SFOEntry = undefined;
 
     //Print header
-    var i : usize = 0;
-    std.debug.warn("\nSFO Header: \tOFF\tALN\tTYPE\tVALS\tTOTS\tDATO\n", .{});
-    while(i < header.count) : (i += 1){
-        entries[i].nameofs = try inFile.reader().readIntNative(u16);
-        entries[i].alignment = try inFile.reader().readIntNative(u8);
-        entries[i].typec = try inFile.reader().readIntNative(u8);
-        entries[i].valsize = try inFile.reader().readIntNative(u32);
-        entries[i].totalsize = try inFile.reader().readIntNative(u32);
-        entries[i].dataofs = try inFile.reader().readIntNative(u32);
-        
-        std.debug.warn("SFO Entry {}: \t{}\t{}\t{}\t{}\t{}\t{}\n", .{i, entries[i].nameofs, entries[i].alignment, entries[i].typec, entries[i].valsize, entries[i].totalsize, entries[i].dataofs});
+    var i: usize = 0;
+    std.log.warn("\nSFO Header: \tOFF\tALN\tTYPE\tVALS\tTOTS\tDATO\n", .{});
+    while (i < header.count) : (i += 1) {
+        entries[i].nameofs = try inFile.reader().readInt(u16, .little);
+        entries[i].alignment = try inFile.reader().readByte();
+        entries[i].typec = try inFile.reader().readByte();
+        entries[i].valsize = try inFile.reader().readInt(u32, .little);
+        entries[i].totalsize = try inFile.reader().readInt(u32, .little);
+        entries[i].dataofs = try inFile.reader().readInt(u32, .little);
+
+        std.log.warn("SFO Entry {}: \t{}\t{}\t{}\t{}\t{}\t{}\n", .{ i, entries[i].nameofs, entries[i].alignment, entries[i].typec, entries[i].valsize, entries[i].totalsize, entries[i].dataofs });
     }
-    std.debug.warn("SFO Header End\n\n", .{});
+    std.log.warn("SFO Header End\n\n", .{});
 
     //Print key pairs
     i = 0;
-    while(i < header.count) : (i += 1){
-        var nameStr : [32]u8 = undefined;
-        
+    while (i < header.count) : (i += 1) {
+        var nameStr: [32]u8 = undefined;
+
         //Go to keys table
         try inFile.seekTo(entries[i].nameofs + header.keyofs);
 
-        var size : usize = 0;
-        if( (i + 1) < header.count){
-            size = entries[i+1].nameofs - entries[i].nameofs;
-        }else{
+        var size: usize = 0;
+        if ((i + 1) < header.count) {
+            size = entries[i + 1].nameofs - entries[i].nameofs;
+        } else {
             size = 10;
         }
 
         //Read the key
         _ = try inFile.reader().read(nameStr[0..size]);
-        std.debug.warn("Pair {}: {s} = ", .{i, nameStr[0..size]});
+        std.log.warn("Pair {}: {s} = ", .{ i, nameStr[0..size] });
 
         //Go to the data table
         try inFile.seekTo(entries[i].dataofs + header.valofs);
-        if(entries[i].typec == PSP_TYPE_VAL){
+        if (entries[i].typec == PSP_TYPE_VAL) {
             //Read a value
-            var val = try inFile.reader().readIntNative(u32);
-            std.debug.warn("{}\n", .{val});
-        }else{
+            const val = try inFile.reader().readInt(u32, .little);
+            std.log.warn("{}\n", .{val});
+        } else {
             //Read a string
-            var str : [32]u8 = undefined;
+            var str: [32]u8 = undefined;
             _ = try inFile.reader().read(str[0..entries[i].valsize]);
-            std.debug.warn("\"{s}\"\n", .{str[0..entries[i].valsize]});
+            std.log.warn("\"{s}\"\n", .{str[0..entries[i].valsize]});
         }
-
     }
 }

--- a/src/write.zig
+++ b/src/write.zig
@@ -1,52 +1,62 @@
 const std = @import("std");
 const process = std.process;
-usingnamespace @import("common.zig");
 const io = std.io;
 const mem = std.mem;
 const fs = std.fs;
 
+const common = @import("common.zig");
+const EntryContainer = common.EntryContainer;
+const SFOHeader = common.SFOHeader;
+const SFOEntry = common.SFOEntry;
+const PSP_TYPE_STR = common.PSP_TYPE_STR;
+const PSF_MAGIC_NUM = common.PSF_MAGIC_NUM;
+const PSF_VERSION = common.PSF_VERSION;
+const PSP_TYPE_VAL = common.PSP_TYPE_VAL;
+
+const g_defaults = common.g_defaults;
+var gVals = &common.gVals;
+
 pub fn writeSFO() !void {
     //Write our SFO!
 
+    //Allocator setup
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
     //Get args
-    var arg_it = process.args();
+    var arg_it = try process.argsWithAllocator(allocator);
 
     // Skip executable
     _ = arg_it.skip();
     // Skip command
     _ = arg_it.skip();
 
-    //Allocator setup
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-
-    const allocator = &arena.allocator;
-
     //Get our title - if it doesn't exist - error out
-    var title = try (arg_it.next(allocator) orelse{
-        std.debug.warn("Usage: sfotool write TITLE <output.SFO>\n", .{});
+    const title = arg_it.next() orelse {
+        std.log.warn("Usage: sfotool write TITLE <output.SFO>\n", .{});
         return;
-    });
+    };
 
-    if(std.mem.eql(u8, title, "-h")){
-        std.debug.warn("Usage: sfotool write TITLE <output.SFO>\n", .{});
+    if (std.mem.eql(u8, title, "-h")) {
+        std.log.warn("Usage: sfotool write TITLE <output.SFO>\n", .{});
         return;
     }
 
     //Get our file - if it doesn't exist - error out
-    var outputFile = try (arg_it.next(allocator) orelse{
-        std.debug.warn("Usage: sfotool write TITLE <output.SFO>\n", .{});
+    const outputFile = arg_it.next() orelse {
+        std.log.warn("Usage: sfotool write TITLE <output.SFO>\n", .{});
         return;
-    });
+    };
 
-    if(std.mem.eql(u8, outputFile, "-h")){
-        std.debug.warn("Usage: sfotool write TITLE <output.SFO>\n", .{});
+    if (std.mem.eql(u8, outputFile, "-h")) {
+        std.log.warn("Usage: sfotool write TITLE <output.SFO>\n", .{});
         return;
     }
 
     //Copy the defaults into a value array
-    var i : usize = 0;
-    while(i < 8) : (i += 1){
+    var i: usize = 0;
+    while (i < 8) : (i += 1) {
         gVals[i] = g_defaults[i];
     }
 
@@ -54,95 +64,97 @@ pub fn writeSFO() !void {
     gVals[i] = EntryContainer{
         .name = "TITLE",
         .typec = PSP_TYPE_STR,
-        .value  = 0,
-        .data  = title,
+        .value = 0,
+        .data = title,
     };
 
     //We use buffers to write to
-    var head : [8192]u8 = [_]u8{0} ** 8192;
-    var keys : [8192]u8 = [_]u8{0} ** 8192;
-    var data : [8192]u8 = [_]u8{0} ** 8192;
+    var head: [8192]u8 = [_]u8{0} ** 8192;
+    var keys: [8192]u8 = [_]u8{0} ** 8192;
+    var data: [8192]u8 = [_]u8{0} ** 8192;
 
     //Tracker pointers
-    var h: [*]SFOHeader = undefined;
-    var e: [*]SFOEntry = undefined;
+    var h: *align(1) SFOHeader = undefined;
+    var el: [*]SFOEntry = undefined;
     var k: [*]u8 = undefined;
     var d: [*]u8 = undefined;
 
-    h = @ptrCast([*]SFOHeader, &head);
-    e = @intToPtr([*]SFOEntry, @ptrToInt(&head) + @sizeOf(SFOHeader));
+    h = @ptrCast(&head);
+    el = @ptrFromInt(@intFromPtr(&head) + @sizeOf(SFOHeader));
     k = &keys;
     d = &data;
 
     //Header layout
     h.*.magic = PSF_MAGIC_NUM;
     h.*.version = PSF_VERSION;
-    
+
     i = 0;
-    while(i < 9) : (i += 1){
+    while (i < 9) : (i += 1) {
+        const e = &el[i];
+
         //Increment count
-        h.*.count = @truncate(u32, i) + 1;
+        h.*.count = @as(u32, @truncate(i)) + 1;
 
         //This name is offset
-        e.*.nameofs = @truncate(u16, (@ptrToInt(k) - @ptrToInt(&keys)));
+        e.*.nameofs = @as(u16, @truncate((@intFromPtr(k) - @intFromPtr(&keys))));
         //This name is offset
-        e.*.dataofs = @truncate(u16, (@ptrToInt(d) - @ptrToInt(&data)));
+        e.*.dataofs = @as(u16, @truncate((@intFromPtr(d) - @intFromPtr(&data))));
 
         //Align by 4
         e.*.alignment = 4;
 
         //What is the type?
-        e.*.typec = @intCast(u8, @truncate(i8, gVals[i].typec));
+        e.*.typec = @as(u8, @intCast(@as(i8, @truncate(gVals[i].typec))));
 
         //Put key inside
-        std.mem.copy(u8, keys[(@ptrToInt(k) - @ptrToInt(&keys))..], gVals[i].name);
+        std.mem.copyForwards(u8, keys[(@intFromPtr(k) - @intFromPtr(&keys))..], gVals[i].name);
         k += gVals[i].name.len + 1;
 
         //Value set
-        if(e.*.typec == PSP_TYPE_VAL){
+        if (e.*.typec == PSP_TYPE_VAL) {
             //Set values in data buffer
             e.*.valsize = 4;
             e.*.totalsize = 4;
-            @ptrCast(*u32, @alignCast(4, d)).* = gVals[i].value;
+            @as(*u32, @ptrCast(@alignCast(d))).* = gVals[i].value;
             d += 4;
-        }else{
+        } else {
             //Copy string to data buffer
-            var totalsize : usize = 0;
-            var valsize : usize = 0;
+            var totalsize: usize = 0;
+            var valsize: usize = 0;
 
             valsize = gVals[i].data.?.len + 1;
             totalsize = (valsize + 3) & ~@as(usize, 3);
-            e.*.valsize = @truncate(u32, valsize);
-            e.*.totalsize = @truncate(u32, totalsize);
+            e.*.valsize = @as(u32, @truncate(valsize));
+            e.*.totalsize = @as(u32, @truncate(totalsize));
 
-            @memset(d, 0, totalsize);
-            std.mem.copy(u8, data[(@ptrToInt(d) - @ptrToInt(&data))..], gVals[i].data.?);
+            @memset(d[0..totalsize], 0);
+            std.mem.copyForwards(u8, data[(@intFromPtr(d) - @intFromPtr(&data))..], gVals[i].data.?);
             d += totalsize;
         }
-        e += 1;
+        // e += 1;
     }
-    
+
     //Get the header size
-    var head_size : usize = (@ptrToInt(e) - @ptrToInt(&head));
-    h.*.keyofs = @truncate(u32, head_size);
+    const head_size: usize = (@intFromPtr(&el[i]) - @intFromPtr(&head));
+    h.*.keyofs = @as(u32, @truncate(head_size));
 
     //Calculate key and data size
-    var key_size : usize = (@ptrToInt(k) - @ptrToInt(&keys));
-    var data_size : usize = (@ptrToInt(d) - @ptrToInt(&data));
-    
+    var key_size: usize = (@intFromPtr(k) - @intFromPtr(&keys));
+    const data_size: usize = (@intFromPtr(d) - @intFromPtr(&data));
+
     //Align keys
-    var @"align" : u32 = 3 - @truncate(u32, key_size & 3);
+    var @"align": u32 = 3 - @as(u32, @truncate(key_size & 3));
     while (@"align" < 3) {
         k += 1;
         @"align" -%= 1;
     }
-    key_size = (@ptrToInt(k) - @ptrToInt(&keys));
+    key_size = (@intFromPtr(k) - @intFromPtr(&keys));
 
     //Value offset is after headers and keys
-    h.*.valofs = @truncate(u32, h.*.keyofs + key_size);
-    
+    h.*.valofs = @as(u32, @truncate(h.*.keyofs + key_size));
+
     //Open File
-    var of = try fs.cwd().createFile(outputFile, fs.File.CreateFlags {.truncate = true});
+    var of = try fs.cwd().createFile(outputFile, fs.File.CreateFlags{ .truncate = true });
     defer of.close();
 
     //Write data
@@ -150,5 +162,5 @@ pub fn writeSFO() !void {
     _ = try of.writeAll(keys[0..key_size]);
     _ = try of.writeAll(data[0..data_size]);
 
-    std.debug.warn("SFO Saved!\n", .{});
+    std.log.warn("SFO Saved!\n", .{});
 }


### PR DESCRIPTION
Updated the SFO tool to compile under Zig version both `0.12.0-dev.3653+e45bdc6bd` and `0.13.0-dev.267+793f820b3`.

Any format/whitespace changes are a result of saving with `zig fmt`

Unable to currently really know if the tool is working correctly for one reason:
- the main build in Zig-PSP repo currently errors out when trying to do a freestanding build (Internal Zig error with LLVM emit)